### PR TITLE
fix: support dates before unix epoch

### DIFF
--- a/simpledatepicker.js
+++ b/simpledatepicker.js
@@ -581,7 +581,7 @@
       this.listeners = {};
 
       // Regexp used to extract the date from a day element.
-      this.timeMatcher = new RegExp(this.classes.time + '-(\\d+)');
+      this.timeMatcher = new RegExp(this.classes.time + '-(-?\\d+)');
 
       this.selection = [];
 


### PR DESCRIPTION
Dates before 1 Jan 1970 use a negative timestamp so we need to match those. 

Follow-up: ideally refactor to store the dates as ISO 8601 instead of timestamps...